### PR TITLE
feature: Replace Decimal with int representation

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -104,3 +104,4 @@ exclude_lines =
     # ignore non-implementations
     ^\s*\.\.\.
     ^\s*if TYPE_CHECKING:$
+    ^\s*case no_match:$

--- a/src/immoney/_cache.py
+++ b/src/immoney/_cache.py
@@ -19,5 +19,5 @@ class InstanceCache(type):
     def __instantiate(cls, *args: object) -> object:
         return super().__call__(*args)
 
-    def __call__(cls, *args: object) -> Any:
-        return cls.__instantiate(*cls._normalize(*args))
+    def __call__(cls, *args: object, **kwargs: object) -> Any:
+        return cls.__instantiate(*cls._normalize(*args, **kwargs))

--- a/src/immoney/_parsers.py
+++ b/src/immoney/_parsers.py
@@ -1,0 +1,30 @@
+from decimal import Decimal
+from decimal import InvalidOperation
+from typing import NewType
+
+from .errors import ParseError
+
+Nat = NewType("Nat", int)
+
+
+def parse_nat(value: int) -> Nat:
+    if value < 0:
+        raise ParseError("Cannot parse from negative value")
+    return Nat(value)
+
+
+def approximate_decimal_subunits(
+    main_unit: Decimal | str,
+    subunit_per_main: int,
+) -> Decimal:
+    if isinstance(main_unit, str):
+        try:
+            main_unit = Decimal(main_unit)
+        except InvalidOperation as exception:
+            raise ParseError("Could not parse Money from the given str") from exception
+
+    if main_unit.is_nan():
+        raise ParseError("Cannot parse from NaN")
+    if not main_unit.is_finite():
+        raise ParseError("Cannot parse from non-finite")
+    return main_unit * subunit_per_main

--- a/tests/strategies.py
+++ b/tests/strategies.py
@@ -3,12 +3,15 @@ from __future__ import annotations
 from typing import Final
 
 from hypothesis.strategies import decimals
+from hypothesis.strategies import integers
 
-max_valid_sek: Final = 10_000_000_000_000_000_000_000_000 - 1
-valid_sek: Final = decimals(
+valid_sek_decimals: Final = decimals(
     min_value=0,
-    max_value=max_valid_sek,
+    max_value=10_000_000_000_000_000_000_000_000 - 1,
     places=2,
     allow_nan=False,
     allow_infinity=False,
 )
+
+valid_money_subunits: Final = integers(min_value=0)
+valid_overdraft_subunits: Final = integers(min_value=1)

--- a/tests/test_arithmetic.py
+++ b/tests/test_arithmetic.py
@@ -1,14 +1,15 @@
+import operator
+from functools import reduce
+
+from hypothesis import example
 from hypothesis import given
 from hypothesis.strategies import integers
 from hypothesis.strategies import lists
-from typing_extensions import assert_type
 
 from immoney import Money
 from immoney import Overdraft
 from immoney.currencies import SEK
 from immoney.currencies import SEKType
-
-from .strategies import max_valid_sek
 
 
 def _to_integer_subunit(value: Money[SEKType] | Overdraft[SEKType]) -> int:
@@ -19,15 +20,24 @@ def _from_integer_subunit(value: int) -> Money[SEKType] | Overdraft[SEKType]:
     return SEK.from_subunit(value) if value >= 0 else SEK.overdraft_from_subunit(-value)
 
 
-@given(lists(integers(max_value=max_valid_sek, min_value=-max_valid_sek), min_size=1))
-def test_arithmetics(values: list[int]):
-    monetary_sum: Money[SEKType] | Overdraft[SEKType] = sum(
-        (_from_integer_subunit(value) for value in values),
-        SEK(0),
-    )
-    assert_type(
-        monetary_sum,
-        Money[SEKType] | Overdraft[SEKType],
-    )
+@given(lists(integers(), min_size=1))
+@example([1])
+@example([0, -1])
+@example([10000000000000000000000000001])
+def test_sequence_of_additions(values: list[int]):
+    monetary_sum = sum((_from_integer_subunit(value) for value in values), SEK(0))
     int_sum = sum(values)
     assert int_sum == _to_integer_subunit(monetary_sum)
+
+
+@given(lists(integers(), min_size=1))
+@example([1])
+@example([0, -1])
+@example([10000000000000000000000000001])
+def test_sequence_of_subtractions(values: list[int]):
+    monetary_delta = reduce(
+        operator.sub,
+        (_from_integer_subunit(value) for value in values),
+    )
+    int_delta = reduce(operator.sub, values)
+    assert int_delta == _to_integer_subunit(monetary_delta)


### PR DESCRIPTION
This commit changes to use plain int as internal value type for Money and Overdraft.

- Closes #50.