### PR TITLE
Implement missing subunit fraction operations

### DIFF
--- a/src/immoney/_base.py
+++ b/src/immoney/_base.py
@@ -469,6 +469,21 @@ class SubunitFraction(Frozen, Generic[C_co], metaclass=InstanceCache):
     def __radd__(self, other: Money[C_co] | Overdraft[C_co]) -> Self:
         return self.__add__(other)
 
+    def __sub__(
+        self,
+        other: SubunitFraction[C_co] | Money[C_co] | Overdraft[C_co],
+    ) -> Self:
+        if isinstance(other, SubunitFraction) and self.currency == other.currency:
+            return SubunitFraction(self.value - other.value, self.currency)
+        if isinstance(other, Money) and self.currency == other.currency:
+            return SubunitFraction(self.value - other.subunits, self.currency)
+        if isinstance(other, Overdraft) and self.currency == other.currency:
+            return SubunitFraction(self.value + other.subunits, self.currency)
+        return NotImplemented
+
+    def __rsub__(self, other: Money[C_co] | Overdraft[C_co]) -> Self:
+        return self.__sub__(-other)
+
     @classmethod
     def from_money(
         cls,

--- a/src/immoney/_base.py
+++ b/src/immoney/_base.py
@@ -521,6 +521,32 @@ class SubunitFraction(Frozen, Generic[C_co], metaclass=InstanceCache):
     def __rmul__(self, other: int | Fraction) -> Self:
         return self.__mul__(other)
 
+    @overload
+    def __truediv__(self, other: int) -> Self:
+        ...
+
+    @overload
+    def __truediv__(self, other: Fraction) -> Self:
+        ...
+
+    def __truediv__(self, other: object) -> Self:
+        if isinstance(other, (int, Fraction)):
+            return SubunitFraction(self.value / other, self.currency)
+        return NotImplemented
+
+    @overload
+    def __rtruediv__(self, other: int) -> Self:
+        ...
+
+    @overload
+    def __rtruediv__(self, other: Fraction) -> Self:
+        ...
+
+    def __rtruediv__(self, other: object) -> Self:
+        if isinstance(other, (int, Fraction)):
+            return SubunitFraction(other / self.value, self.currency)
+        return NotImplemented
+
     @classmethod
     def from_money(
         cls,

--- a/tests/test_subunit_fraction.py
+++ b/tests/test_subunit_fraction.py
@@ -373,3 +373,64 @@ class TestMul:
             ),
         ):
             b * a  # type: ignore[operator]
+
+
+class TestTruediv:
+    @pytest.mark.parametrize(
+        ("a", "b", "expected"),
+        [
+            (SEK.fraction(3, 4), 2, SEK.fraction(3, 8)),
+            (SEK.fraction(3, 4), Fraction(1, 3), SEK.fraction(9, 4)),
+        ],
+    )
+    def test_can_truediv(
+        self,
+        a: SubunitFraction[SEKType],
+        b: int | Fraction,
+        expected: SubunitFraction[SEKType],
+    ) -> None:
+        assert_type(a / b, SubunitFraction[SEKType])
+        assert a / b == expected
+
+    @pytest.mark.parametrize(
+        ("a", "b", "expected"),
+        [
+            (2, SEK.fraction(3, 4), SEK.fraction(8, 3)),
+            (Fraction(1, 3), SEK.fraction(3, 4), SEK.fraction(4, 9)),
+        ],
+    )
+    def test_can_rtruediv(
+        self,
+        a: int | Fraction,
+        b: SubunitFraction[SEKType],
+        expected: SubunitFraction[SEKType],
+    ) -> None:
+        assert_type(a / b, SubunitFraction[SEKType])
+        assert a / b == expected
+
+    @pytest.mark.parametrize(
+        ("a", "b"),
+        (
+            (SEK.fraction(997, 3), SEK(1)),
+            (SEK.fraction(997, 3), SEK.overdraft(1)),
+            (SEK.fraction(997, 3), object()),
+            (SEK.fraction(997, 3), NOK.fraction(997, 3)),
+        ),
+    )
+    def test_raises_type_error_for_invalid_other(
+        self,
+        a: SubunitFraction[Currency],
+        b: object,
+    ) -> None:
+        with pytest.raises(
+            TypeError,
+            match=r"^unsupported operand type\(s\) for /: 'SubunitFraction' and",
+        ):
+            a / b  # type: ignore[operator]
+        with pytest.raises(
+            TypeError,
+            match=(
+                r"^unsupported operand type\(s\) for /: '(\w+)' and 'SubunitFraction'$"
+            ),
+        ):
+            b / a  # type: ignore[operator]

--- a/tests/test_subunit_fraction.py
+++ b/tests/test_subunit_fraction.py
@@ -253,3 +253,73 @@ class TestAdd:
             ),
         ):
             b + a  # type: ignore[operator]
+
+
+class TestSub:
+    @pytest.mark.parametrize(
+        ("a", "b", "expected"),
+        [
+            (
+                SubunitFraction(Fraction(3, 4), SEK),
+                SubunitFraction(Fraction(1, 2), SEK),
+                SubunitFraction(Fraction(1, 4), SEK),
+            ),
+            (
+                SubunitFraction(Fraction(16988, 51), SEK),
+                SubunitFraction(Fraction(997, 3), SEK),
+                SubunitFraction(Fraction(13, 17), SEK),
+            ),
+            (
+                SubunitFraction(Fraction(1000, 3), SEK),
+                SEK("0.01"),
+                SubunitFraction(Fraction(997, 3), SEK),
+            ),
+            (
+                SubunitFraction(Fraction(994, 3), SEK),
+                SEK.overdraft("0.01"),
+                SubunitFraction(Fraction(997, 3), SEK),
+            ),
+        ],
+    )
+    def test_can_subtract(
+        self,
+        a: SubunitFraction[SEKType],
+        b: SubunitFraction[SEKType] | Money[SEKType] | Overdraft[SEKType],
+        expected: SubunitFraction[SEKType],
+    ) -> None:
+        c = a - b
+        assert_type(c, SubunitFraction[SEKType])
+        assert c == expected
+
+        assert_type(a - c, SubunitFraction[SEKType])
+        assert a - c == b
+
+    @pytest.mark.parametrize(
+        ("a", "b"),
+        (
+            (
+                SubunitFraction(Fraction(997, 3), SEK),
+                SubunitFraction(Fraction(997, 3), NOK),
+            ),
+            (SubunitFraction(Fraction(997, 3), SEK), NOK(1)),
+            (SubunitFraction(Fraction(997, 3), SEK), NOK.overdraft(1)),
+            (SubunitFraction(Fraction(997, 3), SEK), 1),
+        ),
+    )
+    def test_raises_type_error_for_invalid_other(
+        self,
+        a: SubunitFraction[Currency],
+        b: object,
+    ) -> None:
+        with pytest.raises(
+            TypeError,
+            match=r"^unsupported operand type\(s\) for \-: 'SubunitFraction' and",
+        ):
+            a - b  # type: ignore[operator]
+        with pytest.raises(
+            TypeError,
+            match=(
+                r"^unsupported operand type\(s\) for \-: '(\w+)' and 'SubunitFraction'$"
+            ),
+        ):
+            b - a  # type: ignore[operator]

--- a/tests/test_subunit_fraction.py
+++ b/tests/test_subunit_fraction.py
@@ -8,13 +8,16 @@ import pytest
 from hypothesis import example
 from hypothesis import given
 from hypothesis.strategies import integers
+from typing_extensions import assert_type
 
 from immoney import Currency
 from immoney import Money
+from immoney import Overdraft
 from immoney import Round
 from immoney import SubunitFraction
 from immoney.currencies import NOK
 from immoney.currencies import SEK
+from immoney.currencies import SEKType
 from immoney.errors import ParseError
 
 from .strategies import monies
@@ -182,3 +185,71 @@ def test_round_either_returns_money_for_positive_fraction() -> None:
     assert SEK("3.32") == fraction.round_either(Round.HALF_UP)
     assert SEK("3.32") == fraction.round_either(Round.HALF_EVEN)
     assert SEK("3.32") == fraction.round_either(Round.HALF_DOWN)
+
+
+class TestAdd:
+    @pytest.mark.parametrize(
+        ("a", "b", "expected"),
+        [
+            (
+                SubunitFraction(Fraction(1, 2), SEK),
+                SubunitFraction(Fraction(1, 4), SEK),
+                SubunitFraction(Fraction(3, 4), SEK),
+            ),
+            (
+                SubunitFraction(Fraction(997, 3), SEK),
+                SubunitFraction(Fraction(13, 17), SEK),
+                SubunitFraction(Fraction(16988, 51), SEK),
+            ),
+            (
+                SubunitFraction(Fraction(997, 3), SEK),
+                SEK("0.01"),
+                SubunitFraction(Fraction(1000, 3), SEK),
+            ),
+            (
+                SubunitFraction(Fraction(997, 3), SEK),
+                SEK.overdraft("0.01"),
+                SubunitFraction(Fraction(994, 3), SEK),
+            ),
+        ],
+    )
+    def test_can_add(
+        self,
+        a: SubunitFraction[SEKType],
+        b: SubunitFraction[SEKType] | Money[SEKType] | Overdraft[SEKType],
+        expected: SubunitFraction[SEKType],
+    ) -> None:
+        assert_type(a + b, SubunitFraction[SEKType])
+        assert_type(b + a, SubunitFraction[SEKType])
+        assert a + b == expected
+        assert b + a == expected
+
+    @pytest.mark.parametrize(
+        ("a", "b"),
+        (
+            (
+                SubunitFraction(Fraction(997, 3), SEK),
+                SubunitFraction(Fraction(997, 3), NOK),
+            ),
+            (SubunitFraction(Fraction(997, 3), SEK), NOK(1)),
+            (SubunitFraction(Fraction(997, 3), SEK), NOK.overdraft(1)),
+            (SubunitFraction(Fraction(997, 3), SEK), 1),
+        ),
+    )
+    def test_raises_type_error_for_invalid_other(
+        self,
+        a: SubunitFraction[Currency],
+        b: object,
+    ) -> None:
+        with pytest.raises(
+            TypeError,
+            match=r"^unsupported operand type\(s\) for \+: 'SubunitFraction' and",
+        ):
+            a + b  # type: ignore[operator]
+        with pytest.raises(
+            TypeError,
+            match=(
+                r"^unsupported operand type\(s\) for \+: '(\w+)' and 'SubunitFraction'$"
+            ),
+        ):
+            b + a  # type: ignore[operator]

--- a/tests/test_subunit_fraction.py
+++ b/tests/test_subunit_fraction.py
@@ -323,3 +323,53 @@ class TestSub:
             ),
         ):
             b - a  # type: ignore[operator]
+
+
+class TestMul:
+    @pytest.mark.parametrize(
+        ("a", "b", "expected"),
+        [
+            (SEK.fraction(3, 4), 2, SEK.fraction(3, 2)),
+            (SEK.fraction(3, 4), Fraction(1, 3), SEK.fraction(1, 4)),
+        ],
+    )
+    def test_can_multiply(
+        self,
+        a: SubunitFraction[SEKType],
+        b: int | Fraction,
+        expected: SubunitFraction[SEKType],
+    ) -> None:
+        assert_type(a * b, SubunitFraction[SEKType])
+        assert_type(b * a, SubunitFraction[SEKType])
+        assert a * b == expected
+        assert b * a == expected
+
+    @pytest.mark.parametrize(
+        ("a", "b"),
+        (
+            (
+                SubunitFraction(Fraction(997, 3), SEK),
+                SubunitFraction(Fraction(997, 3), SEK),
+            ),
+            (SubunitFraction(Fraction(997, 3), SEK), SEK(1)),
+            (SubunitFraction(Fraction(997, 3), SEK), SEK.overdraft(1)),
+            (SubunitFraction(Fraction(997, 3), SEK), object()),
+        ),
+    )
+    def test_raises_type_error_for_invalid_other(
+        self,
+        a: SubunitFraction[Currency],
+        b: object,
+    ) -> None:
+        with pytest.raises(
+            TypeError,
+            match=r"^unsupported operand type\(s\) for \*: 'SubunitFraction' and",
+        ):
+            a * b  # type: ignore[operator]
+        with pytest.raises(
+            TypeError,
+            match=(
+                r"^unsupported operand type\(s\) for \*: '(\w+)' and 'SubunitFraction'$"
+            ),
+        ):
+            b * a  # type: ignore[operator]


### PR DESCRIPTION
- Partially addresses #75.
- Adds an ulterior overload signature to `Currency.fraction()` for convenience, allowing instantiation with e.g. `SEK.fraction(5, 3)`.