### PR TITLE
fix: Support extracting generic bound from TypeVar

### DIFF
--- a/goose.yaml
+++ b/goose.yaml
@@ -28,12 +28,14 @@ environments:
       - prettier
 
 hooks:
-  - id: check-manifest
-    environment: check-manifest
-    command: check-manifest
-    parameterize: false
-    read_only: true
-    args: [--no-build-isolation]
+  # Commented out until there's a fix for pinning setuptools.
+  # https://github.com/antonagestam/goose/issues/30
+  # - id: check-manifest
+  #   environment: check-manifest
+  #   command: check-manifest
+  #   parameterize: false
+  #   read_only: true
+  #   args: [--no-build-isolation]
 
   - id: prettier
     environment: node

--- a/src/immoney/_pydantic.py
+++ b/src/immoney/_pydantic.py
@@ -39,9 +39,16 @@ class OverdraftDict(TypedDict):
 
 def extract_currency_type_arg(source_type: type) -> type[Currency]:
     match get_args(source_type):
-        case (type() as currency_type,):
-            assert issubclass(currency_type, Currency)
+        case (type() as currency_type,) if issubclass(currency_type, Currency):
             return currency_type
+        # TypeVar with Currency bound.
+        case (TypeVar(__bound__=type() as currency_type),) if issubclass(
+            currency_type, Currency
+        ):
+            return currency_type
+        # TypeVar without bound.
+        case (TypeVar(__bound__=None),):
+            return Currency
         case invalid:  # pragma: no cover
             raise TypeError(f"Invalid type args: {invalid!r}.")
 


### PR DESCRIPTION
Adds support for Pydantic models that are generic with a currency type.

Fixes #87.