### PR TITLE
feature: Support pydantic-core 2.10+

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -67,7 +67,8 @@ repos:
           - abcattrs==0.3.2
           - typing-extensions==4.6.3
           - hypothesis==6.54.4
-          - pydantic==2.0b3
+          - pydantic==2.5.2
+          - pydantic-core==2.14.5
           - types-babel==2.11.0.15
   - repo: https://github.com/pre-commit/mirrors-prettier
     rev: "v2.7.1"

--- a/setup.cfg
+++ b/setup.cfg
@@ -40,6 +40,9 @@ immoney = py.typed
 [options.extras_require]
 pydantic =
     pydantic>=2.0.3
+    # 2.10 deprecates some functions under pydantic.core_schema.*, forcing dropping
+    # support for prior versions.
+    pydantic-core>=2.10
 
 babel =
     babel>=2.12.1


### PR DESCRIPTION
pydantic-core 2.10 deprecated some functions in the `pydantic_core.core_schema.*` namespace. In order to both be compatible with future (no deprecation errors), and have working type checking, there's no choice but to drop support for pydantic-core versions <2.10.

Because this drops support for some pydantic-core versions, it is a breaking change.